### PR TITLE
feat: add identity pool and iam roles

### DIFF
--- a/src/transformer/schema-transformer.ts
+++ b/src/transformer/schema-transformer.ts
@@ -136,8 +136,8 @@ export class SchemaTransformer {
     const schema = fs.readFileSync(this.schemaPath);
     const cfdoc = transformer.transform(schema.toString());
 
-    // TODO: Get Unauth Role and Auth Role policies for authorization stuff
     this.unauthRolePolicy = cfdoc.rootStack.Resources?.UnauthRolePolicy01 as Resource || undefined;
+    this.authRolePolicy = cfdoc.rootStack.Resources?.AuthRolePolicy01 as Resource || undefined;
 
     this.writeSchema(cfdoc.schema);
     this.writeResolversToFile(cfdoc.resolvers);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -434,5 +434,476 @@ test('DynamoDB Stream Enabled Convenience Method', () => {
       StreamViewType: StreamViewType.NEW_IMAGE,
     },
   });
+});
 
+test('GraphQL API W/ IAM Auth Roles Created', () => {
+  const mockApp = new App();
+  const stack = new Stack(mockApp, 'iam-auth-stack');
+
+  const appSyncTransformer = new AppSyncTransformer(stack, 'test-transformer', {
+    schemaPath: testSchemaPath,
+    apiName: 'iam-auth-api',
+    authorizationConfig: {
+      defaultAuthorization: {
+        authorizationType: AuthorizationType.IAM,
+      },
+    },
+  });
+
+  expect(stack).toHaveResource('AWS::CloudFormation::Stack');
+
+  expect(appSyncTransformer.nestedAppsyncStack).toHaveResource('AWS::AppSync::GraphQLApi', {
+    AuthenticationType: 'AWS_IAM',
+    Name: 'iam-auth-api',
+  });
+
+  expect(appSyncTransformer.nestedAppsyncStack).toHaveResourceLike('AWS::IAM::Policy', {
+    PolicyDocument: {
+      Statement: [
+        {
+          Action: ['mobileanalytics:PutEvents', 'cognito-sync:*', 'cognito-identity:*'],
+          Effect: 'Allow',
+          Resource: '*',
+        },
+        {
+          Action: 'appsync:GraphQL',
+          Effect: 'Allow',
+          Resource: [
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Customer/*',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Mutation/fields/updateCustomer',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Query/fields/getCustomer',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Query/fields/listCustomers',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Subscription/fields/onCreateCustomer',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Subscription/fields/onUpdateCustomer',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Subscription/fields/onDeleteCustomer',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Product/*',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Query/fields/getProduct',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Query/fields/listProducts',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Subscription/fields/onCreateProduct',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Subscription/fields/onUpdateProduct',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Subscription/fields/onDeleteProduct',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/User/*',
+                ],
+              ],
+            },
+          ],
+        },
+      ],
+      Version: '2012-10-17',
+    },
+    PolicyName: 'AuthenticatedRoleDefaultPolicy8B1AC271',
+    Roles: [
+      {
+        Ref: 'AuthenticatedRole86104F1A',
+      },
+    ],
+  });
+
+  expect(appSyncTransformer.nestedAppsyncStack).toHaveResourceLike('AWS::IAM::Policy', {
+    PolicyDocument: {
+      Statement: [
+        {
+          Action: ['mobileanalytics:PutEvents', 'cognito-sync:*'],
+          Effect: 'Allow',
+          Resource: '*',
+        },
+        {
+          Action: 'appsync:GraphQL',
+          Effect: 'Allow',
+          Resource: [
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Product/*',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Query/fields/getProduct',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Query/fields/listProducts',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Subscription/fields/onCreateProduct',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Subscription/fields/onUpdateProduct',
+                ],
+              ],
+            },
+            {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:appsync:',
+                  {
+                    Ref: 'AWS::Region',
+                  },
+                  ':',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':apis/',
+                  {
+                    'Fn::GetAtt': ['testtransformerapi4F4ACB56', 'ApiId'],
+                  },
+                  '/types/Subscription/fields/onDeleteProduct',
+                ],
+              ],
+            },
+          ],
+        },
+      ],
+      Version: '2012-10-17',
+    },
+    PolicyName: 'UnauthenticatedRoleDefaultPolicyAD16B58E',
+    Roles: [
+      {
+        Ref: 'UnauthenticatedRole01CC4258',
+      },
+    ],
+  });
 });


### PR DESCRIPTION
This PR adds richer IAM auth support by automating the creation of an Identity Pool and IAM roles based on the `@auth` directive transformations.

@kcwinner let me know your thoughts here. I've been manually keeping these in sync in my projects, and thought it would be nice to handle it based on the transformer output. If you'd rather go about this a different way, I'll take no offense!

If this seems like a good addition, I'll also update the readme to clarify that this support has been added.

One outstanding question of mine is whether we should automatically update the AppSync auth configuration to include IAM as an auth type if these roles are present in the transformer output. As it stands, we could generate these roles and an Identity Pool and they wouldn't be usable if the auth config passed in by the user didn't allow for IAM auth.

Lastly, I also need to add the Identity Pool to the resulting output so that users can interact with it (and get the pertinent details out of the stack). I wanted to get this in front of you sooner than later, and then make those changes if you're interested in this feature.