### PR TITLE
fix: Add support for LSIs and fix GSI primary keys

### DIFF
--- a/API.md
+++ b/API.md
@@ -15,6 +15,7 @@ Name|Description
 [CdkTransformerFunctionResolver](#cdk-appsync-transformer-cdktransformerfunctionresolver)|*No description*
 [CdkTransformerGlobalSecondaryIndex](#cdk-appsync-transformer-cdktransformerglobalsecondaryindex)|*No description*
 [CdkTransformerHttpResolver](#cdk-appsync-transformer-cdktransformerhttpresolver)|*No description*
+[CdkTransformerLocalSecondaryIndex](#cdk-appsync-transformer-cdktransformerlocalsecondaryindex)|*No description*
 [CdkTransformerResolver](#cdk-appsync-transformer-cdktransformerresolver)|*No description*
 [CdkTransformerTable](#cdk-appsync-transformer-cdktransformertable)|*No description*
 [CdkTransformerTableKey](#cdk-appsync-transformer-cdktransformertablekey)|*No description*
@@ -179,6 +180,21 @@ Name | Type | Description
 
 
 
+## struct CdkTransformerLocalSecondaryIndex 🔹 <a id="cdk-appsync-transformer-cdktransformerlocalsecondaryindex"></a>
+
+
+
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**indexName**🔹 | <code>string</code> | <span></span>
+**projection**🔹 | <code>any</code> | <span></span>
+**sortKey**🔹 | <code>[CdkTransformerTableKey](#cdk-appsync-transformer-cdktransformertablekey)</code> | <span></span>
+
+
+
 ## struct CdkTransformerResolver 🔹 <a id="cdk-appsync-transformer-cdktransformerresolver"></a>
 
 
@@ -204,6 +220,7 @@ Name | Type | Description
 -----|------|-------------
 **globalSecondaryIndexes**🔹 | <code>Array<[CdkTransformerGlobalSecondaryIndex](#cdk-appsync-transformer-cdktransformerglobalsecondaryindex)></code> | <span></span>
 **gsiResolvers**🔹 | <code>Array<string></code> | <span></span>
+**localSecondaryIndexes**🔹 | <code>Array<[CdkTransformerLocalSecondaryIndex](#cdk-appsync-transformer-cdktransformerlocalsecondaryindex)></code> | <span></span>
 **partitionKey**🔹 | <code>[CdkTransformerTableKey](#cdk-appsync-transformer-cdktransformertablekey)</code> | <span></span>
 **resolvers**🔹 | <code>Array<string></code> | <span></span>
 **tableName**🔹 | <code>string</code> | <span></span>

--- a/src/appsync-transformer.ts
+++ b/src/appsync-transformer.ts
@@ -438,23 +438,36 @@ export class AppSyncTransformer extends Construct {
       tableProps,
     );
 
-    if (
-      tableData.globalSecondaryIndexes &&
-      tableData.globalSecondaryIndexes.length > 0
-    ) {
-      tableData.globalSecondaryIndexes.forEach((gsi: any) => {
-        table.addGlobalSecondaryIndex({
-          indexName: gsi.indexName,
-          partitionKey: {
-            name: gsi.partitionKey.name,
-            type: this.convertAttributeType(gsi.partitionKey.type),
-          },
-          projectionType: this.convertProjectionType(
-            gsi.projection.ProjectionType,
-          ),
-        });
+    tableData.localSecondaryIndexes.forEach((lsi: any) => {
+      table.addLocalSecondaryIndex({
+        indexName: lsi.indexName,
+        sortKey: {
+          name: lsi.sortKey.name,
+          type: this.convertAttributeType(lsi.sortKey.type),
+        },
+        projectionType: this.convertProjectionType(
+          lsi.projection.ProjectionType,
+        ),
       });
-    }
+    });
+
+    tableData.globalSecondaryIndexes.forEach((gsi: any) => {
+      table.addGlobalSecondaryIndex({
+        indexName: gsi.indexName,
+        partitionKey: {
+          name: gsi.partitionKey.name,
+          type: this.convertAttributeType(gsi.partitionKey.type),
+        },
+        sortKey: gsi.sortKey && gsi.sortKey.name
+          ? {
+            name: gsi.sortKey.name,
+            type: this.convertAttributeType(gsi.sortKey.type),
+          } : undefined,
+        projectionType: this.convertProjectionType(
+          gsi.projection.ProjectionType,
+        ),
+      });
+    });
 
     return table;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export {
   CdkTransformerResolver,
   CdkTransformerFunctionResolver,
   CdkTransformerHttpResolver,
+  CdkTransformerLocalSecondaryIndex,
   CdkTransformerGlobalSecondaryIndex,
   CdkTransformerTable,
   CdkTransformerTableKey,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -128,6 +128,63 @@ test('Model Tables Created and PITR', () => {
     });
   }
 
+  // Make sure LSI is set correctly on Thread table
+  const threadTable = appSyncTransformer.nestedAppsyncStack.node.findChild('ThreadTable');
+  expect(threadTable).toBeTruthy();
+
+  expect(appSyncTransformer.nestedAppsyncStack).toHaveResource('AWS::DynamoDB::Table', {
+    KeySchema: [
+      { AttributeName: 'forumName', KeyType: 'HASH' },
+      { AttributeName: 'subject', KeyType: 'RANGE' },
+    ],
+    LocalSecondaryIndexes: [
+      {
+        IndexName: 'threadsByLatestPost',
+        KeySchema: [
+          {
+            AttributeName: 'forumName',
+            KeyType: 'HASH',
+          },
+          {
+            AttributeName: 'latestPostAt',
+            KeyType: 'RANGE',
+          },
+        ],
+        Projection: {
+          ProjectionType: 'ALL',
+        },
+      },
+    ],
+  });
+
+  // Make sure GSI is set correctly on Product table
+  const productTable = appSyncTransformer.nestedAppsyncStack.node.findChild('ProductTable');
+  expect(productTable).toBeTruthy();
+
+  expect(appSyncTransformer.nestedAppsyncStack).toHaveResource('AWS::DynamoDB::Table', {
+    KeySchema: [
+      { AttributeName: 'id', KeyType: 'HASH' },
+    ],
+    GlobalSecondaryIndexes: [
+      {
+        IndexName: 'productsByName',
+        KeySchema: [
+          {
+            AttributeName: 'name',
+            KeyType: 'HASH',
+          },
+          {
+            AttributeName: 'added',
+            KeyType: 'RANGE',
+          },
+        ],
+        Projection: {
+          ProjectionType: 'ALL',
+        },
+      },
+    ],
+  });
+
   // Make sure ttl is on Order table
   const orderTable = appSyncTransformer.nestedAppsyncStack.node.findChild('OrderTable');
   expect(orderTable).toBeTruthy();

--- a/test/schema.graphql
+++ b/test/schema.graphql
@@ -16,7 +16,8 @@ type Product
     @auth(rules: [
         { allow: groups, groups: ["Admins"] },
         { allow: public, provider: iam, operations: [read] }
-    ]) {
+    ])
+    @key(name: "productsByName", fields: ["name", "added"], queryField: "productsByName") {
         id: ID!
         name: String!
         description: String!
@@ -36,6 +37,17 @@ type Order @model
         expirationUnixTime: AWSTimestamp! @ttl
 }
 
+type Thread @model
+    @key(fields: ["forumName", "subject"])
+    @key(
+      name: "threadsByLatestPost",
+      fields: ["forumName", "latestPostAt"],
+      queryField: "threadsByLatestPost") {
+        forumName: String!
+        subject:  String!
+        latestPostAt: AWSDateTime!
+        replies: Int!
+}
 
 type Blog @model
   @auth(rules: [{ allow: owner, provider: oidc, identityClaim: "sub" }])


### PR DESCRIPTION
This PR adds support for local secondary indices and fixes the primary key for global secondary indices which should have also the sort key defined. Before this the GSI sort key was always absent. Includes tests for both cases.

Also, thanks @kcwinner for creating this project! I was trying to find something similar from official sources until I finally came across this one. Fully embracing CDK when using the Amplify GraphQL directives makes a lot sense to me.