### PR TITLE
Add additional configuration options

### DIFF
--- a/API.md
+++ b/API.md
@@ -12,6 +12,7 @@ Name|Description
 Name|Description
 ----|-----------
 [AppSyncTransformerProps](#cdk-appsync-transformer-appsynctransformerprops)|*No description*
+[CdkTransformerFieldFunctionResolver](#cdk-appsync-transformer-cdktransformerfieldfunctionresolver)|*No description*
 [CdkTransformerFunctionResolver](#cdk-appsync-transformer-cdktransformerfunctionresolver)|*No description*
 [CdkTransformerGlobalSecondaryIndex](#cdk-appsync-transformer-cdktransformerglobalsecondaryindex)|*No description*
 [CdkTransformerHttpResolver](#cdk-appsync-transformer-cdktransformerhttpresolver)|*No description*
@@ -50,7 +51,8 @@ new AppSyncTransformer(scope: Construct, id: string, props: AppSyncTransformerPr
   * **apiName** (<code>string</code>)  String value representing the api name. __*Default*__: `${id}-api`
   * **authorizationConfig** (<code>[AuthorizationConfig](#aws-cdk-aws-appsync-authorizationconfig)</code>)  Optional. __*Default*__: API_KEY authorization config
   * **customVtlTransformerRootDirectory** (<code>string</code>)  The root directory to use for finding custom resolvers. __*Default*__: process.cwd()
-  * **dynamoDbStreamConfig** (<code>Map<string, [StreamViewType](#aws-cdk-aws-dynamodb-streamviewtype)></code>)  A map of @model type names to stream view type e.g { Blog: StreamViewType.NEW_IMAGE }. __*Optional*__
+  * **dynamoDbStreamConfig** (<code>Map<string, [StreamViewType](#aws-cdk-aws-dynamodb-streamviewtype)></code>)  A map of @model type names to stream view type
+ e.g { Blog: StreamViewType.NEW_IMAGE }. __*Optional*__
   * **enableDynamoPointInTimeRecovery** (<code>boolean</code>)  Whether to enable dynamo Point In Time Recovery. __*Default*__: false
   * **featureFlags** (<code>any</code>)  Optional. __*Default*__: undefined
   * **fieldLogLevel** (<code>[FieldLogLevel](#aws-cdk-aws-appsync-fieldloglevel)</code>)  Optional. __*Default*__: FieldLogLevel.NONE
@@ -71,12 +73,15 @@ Name | Type | Description
 -----|------|-------------
 **appsyncAPI**🔹 | <code>[GraphqlApi](#aws-cdk-aws-appsync-graphqlapi)</code> | The cdk GraphqlApi construct.
 **fieldResolvers**🔹 | <code>Map<string, Array<[Resolver](#aws-cdk-aws-appsync-resolver)>></code> | <span></span>
-**functionResolvers**🔹 | <code>Map<string, Array<[CdkTransformerFunctionResolver](#cdk-appsync-transformer-cdktransformerfunctionresolver)>></code> | The Lambda Function resolvers designated by the function directive https://github.com/kcwinner/cdk-appsync-transformer#functions.
+**functionResolvers**🔹 | <code>Map<string, Array<[CdkTransformerFunctionResolver](#cdk-appsync-transformer-cdktransformerfunctionresolver)>></code> | The Lambda Function resolvers designated by the function directive
+ https://github.com/kcwinner/cdk-appsync-transformer#functions.
 **httpResolvers**🔹 | <code>Map<string, Array<[CdkTransformerHttpResolver](#cdk-appsync-transformer-cdktransformerhttpresolver)>></code> | <span></span>
+**lambdaFieldResolvers**🔹 | <code>Map<string, [CdkTransformerFieldFunctionResolver](#cdk-appsync-transformer-cdktransformerfieldfunctionresolver)></code> | <span></span>
 **nestedAppsyncStack**🔹 | <code>[NestedStack](#aws-cdk-core-nestedstack)</code> | The NestedStack that contains the AppSync resources.
 **outputs**🔹 | <code>[SchemaTransformerOutputs](#cdk-appsync-transformer-schematransformeroutputs)</code> | The outputs from the SchemaTransformer.
 **resolvers**🔹 | <code>Map<string, [CdkTransformerResolver](#cdk-appsync-transformer-cdktransformerresolver)></code> | The AppSync resolvers from the transformer minus any function resolvers.
-**tableMap**🔹 | <code>Map<string, [Table](#aws-cdk-aws-dynamodb-table)></code> | Map of cdk table keys to L2 Table e.g. { 'TaskTable': Table }.
+**tableMap**🔹 | <code>Map<string, [Table](#aws-cdk-aws-dynamodb-table)></code> | Map of cdk table keys to L2 Table
+ e.g. { 'TaskTable': Table }.
 **tableNameMap**🔹 | <code>Map<string, string></code> | Map of cdk table tokens to table names.
 
 ### Methods
@@ -91,7 +96,8 @@ addDynamoDBStream(props: DynamoDBStreamProps): string
 ```
 
 * **props** (<code>[DynamoDBStreamProps](#cdk-appsync-transformer-dynamodbstreamprops)</code>)  *No description*
-  * **modelTypeName** (<code>string</code>)  The @model type name from the graph schema e.g. Blog. 
+  * **modelTypeName** (<code>string</code>)  The @model type name from the graph schema
+ e.g. Blog. 
   * **streamViewType** (<code>[StreamViewType](#aws-cdk-aws-dynamodb-streamviewtype)</code>)  *No description* 
 
 __Returns__:
@@ -99,7 +105,8 @@ __Returns__:
 
 #### addLambdaDataSourceAndResolvers(functionName, id, lambdaFunction, options?)🔹 <a id="cdk-appsync-transformer-appsynctransformer-addlambdadatasourceandresolvers"></a>
 
-Adds the function as a lambdaDataSource to the AppSync api Adds all of the functions resolvers to the AppSync api.
+Adds the function as a lambdaDataSource to the AppSync api
+ Adds all of the functions resolvers to the AppSync api.
 
 ```ts
 addLambdaDataSourceAndResolvers(functionName: string, id: string, lambdaFunction: IFunction, options?: DataSourceOptions): LambdaDataSource
@@ -117,7 +124,8 @@ __Returns__:
 
 #### grantPrivate(grantee)🔹 <a id="cdk-appsync-transformer-appsynctransformer-grantprivate"></a>
 
-Adds an IAM policy statement granting access to the private fields of the AppSync API.
+Adds an IAM policy statement granting access to the private fields of
+ the AppSync API.
 
 Policy is based off of the @auth transformer
 https://docs.amplify.aws/cli/graphql-transformer/auth
@@ -133,7 +141,8 @@ __Returns__:
 
 #### grantPublic(grantee)🔹 <a id="cdk-appsync-transformer-appsynctransformer-grantpublic"></a>
 
-Adds an IAM policy statement granting access to the public fields of the AppSync API.
+Adds an IAM policy statement granting access to the public fields of
+ the AppSync API.
 
 Policy is based off of the @auth transformer
 https://docs.amplify.aws/cli/graphql-transformer/auth
@@ -157,7 +166,8 @@ overrideResolver(props: OverrideResolverProps): void
 
 * **props** (<code>[OverrideResolverProps](#cdk-appsync-transformer-overrideresolverprops)</code>)  *No description*
   * **fieldName** (<code>string</code>)  The fieldname to override e.g. listThings, createStuff. 
-  * **typeName** (<code>string</code>)  Example: Query, Mutation, Subscription For a GSI this might be Post, Comment, etc. 
+  * **typeName** (<code>string</code>)  Example: Query, Mutation, Subscription
+ For a GSI this might be Post, Comment, etc. 
   * **requestMappingTemplateFile** (<code>string</code>)  The full path to the request mapping template file. __*Optional*__
   * **responseMappingTemplateFile** (<code>string</code>)  The full path to the resposne mapping template file. __*Optional*__
 
@@ -180,7 +190,8 @@ Name | Type | Description
 **apiName**?🔹 | <code>string</code> | String value representing the api name.<br/>__*Default*__: `${id}-api`
 **authorizationConfig**?🔹 | <code>[AuthorizationConfig](#aws-cdk-aws-appsync-authorizationconfig)</code> | Optional.<br/>__*Default*__: API_KEY authorization config
 **customVtlTransformerRootDirectory**?🔹 | <code>string</code> | The root directory to use for finding custom resolvers.<br/>__*Default*__: process.cwd()
-**dynamoDbStreamConfig**?🔹 | <code>Map<string, [StreamViewType](#aws-cdk-aws-dynamodb-streamviewtype)></code> | A map of @model type names to stream view type e.g { Blog: StreamViewType.NEW_IMAGE }.<br/>__*Optional*__
+**dynamoDbStreamConfig**?🔹 | <code>Map<string, [StreamViewType](#aws-cdk-aws-dynamodb-streamviewtype)></code> | A map of @model type names to stream view type
+ e.g { Blog: StreamViewType.NEW_IMAGE }.<br/>__*Optional*__
 **enableDynamoPointInTimeRecovery**?🔹 | <code>boolean</code> | Whether to enable dynamo Point In Time Recovery.<br/>__*Default*__: false
 **featureFlags**?🔹 | <code>any</code> | Optional.<br/>__*Default*__: undefined
 **fieldLogLevel**?🔹 | <code>[FieldLogLevel](#aws-cdk-aws-appsync-fieldloglevel)</code> | Optional.<br/>__*Default*__: FieldLogLevel.NONE
@@ -191,6 +202,22 @@ Name | Type | Description
 **tableNames**?🔹 | <code>Map<string, string></code> | A map of names to specify the generated dynamo table names instead of auto generated names.<br/>__*Default*__: undefined
 **transformConfig**?🔹 | <code>any</code> | Optional.<br/>__*Default*__: undefined
 **xrayEnabled**?🔹 | <code>boolean</code> | Determines whether xray should be enabled on the AppSync API.<br/>__*Default*__: false
+
+
+
+## struct CdkTransformerFieldFunctionResolver 🔹 <a id="cdk-appsync-transformer-cdktransformerfieldfunctionresolver"></a>
+
+
+
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**fieldName**🔹 | <code>string</code> | <span></span>
+**requestMappingTemplate**🔹 | <code>string</code> | <span></span>
+**responseMappingTemplate**🔹 | <code>string</code> | <span></span>
+**typeName**🔹 | <code>string</code> | <span></span>
 
 
 
@@ -329,7 +356,8 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|-------------
-**modelTypeName**🔹 | <code>string</code> | The @model type name from the graph schema e.g. Blog.
+**modelTypeName**🔹 | <code>string</code> | The @model type name from the graph schema
+ e.g. Blog.
 **streamViewType**🔹 | <code>[StreamViewType](#aws-cdk-aws-dynamodb-streamviewtype)</code> | <span></span>
 
 
@@ -344,7 +372,8 @@ Name | Type | Description
 Name | Type | Description 
 -----|------|-------------
 **fieldName**🔹 | <code>string</code> | The fieldname to override e.g. listThings, createStuff.
-**typeName**🔹 | <code>string</code> | Example: Query, Mutation, Subscription For a GSI this might be Post, Comment, etc.
+**typeName**🔹 | <code>string</code> | Example: Query, Mutation, Subscription
+ For a GSI this might be Post, Comment, etc.
 **requestMappingTemplateFile**?🔹 | <code>string</code> | The full path to the request mapping template file.<br/>__*Optional*__
 **responseMappingTemplateFile**?🔹 | <code>string</code> | The full path to the resposne mapping template file.<br/>__*Optional*__
 

--- a/API.md
+++ b/API.md
@@ -45,18 +45,21 @@ new AppSyncTransformer(scope: Construct, id: string, props: AppSyncTransformerPr
 * **scope** (<code>[Construct](#aws-cdk-core-construct)</code>)  *No description*
 * **id** (<code>string</code>)  *No description*
 * **props** (<code>[AppSyncTransformerProps](#cdk-appsync-transformer-appsynctransformerprops)</code>)  *No description*
-  * **schemaPath** (<code>string</code>)  Relative path where schema.graphql exists. 
+  * **schemaPath** (<code>string</code>)  Relative path to schema.graphql or a directory containing *.graphql schema files. 
+  * **amplifyTransformers** (<code>Array<any></code>)  Optional. __*Default*__: undefined
   * **apiName** (<code>string</code>)  String value representing the api name. __*Default*__: `${id}-api`
   * **authorizationConfig** (<code>[AuthorizationConfig](#aws-cdk-aws-appsync-authorizationconfig)</code>)  Optional. __*Default*__: API_KEY authorization config
   * **customVtlTransformerRootDirectory** (<code>string</code>)  The root directory to use for finding custom resolvers. __*Default*__: process.cwd()
-  * **dynamoDbStreamConfig** (<code>Map<string, [StreamViewType](#aws-cdk-aws-dynamodb-streamviewtype)></code>)  A map of @model type names to stream view type e.g { Blog: StreamViewType.NEW_IMAGE }. __*Optional*__
+  * **dynamoDbStreamConfig** (<code>Map<string, [StreamViewType](#aws-cdk-aws-dynamodb-streamviewtype)></code>)  A map of @model type names to stream view type e.g { Blog: StreamViewType.NEW_IMAGE }. __*Optional*__
   * **enableDynamoPointInTimeRecovery** (<code>boolean</code>)  Whether to enable dynamo Point In Time Recovery. __*Default*__: false
+  * **featureFlags** (<code>any</code>)  Optional. __*Default*__: undefined
   * **fieldLogLevel** (<code>[FieldLogLevel](#aws-cdk-aws-appsync-fieldloglevel)</code>)  Optional. __*Default*__: FieldLogLevel.NONE
   * **nestedStackName** (<code>string</code>)  Specify a custom nested stack name. __*Default*__: "appsync-nested-stack"
   * **postCdkTransformers** (<code>Array<any></code>)  Optional. __*Default*__: undefined
   * **preCdkTransformers** (<code>Array<any></code>)  Optional. __*Default*__: undefined
   * **syncEnabled** (<code>boolean</code>)  Whether to enable Amplify DataStore and Sync Tables. __*Default*__: false
   * **tableNames** (<code>Map<string, string></code>)  A map of names to specify the generated dynamo table names instead of auto generated names. __*Default*__: undefined
+  * **transformConfig** (<code>any</code>)  Optional. __*Default*__: undefined
   * **xrayEnabled** (<code>boolean</code>)  Determines whether xray should be enabled on the AppSync API. __*Default*__: false
 
 
@@ -67,12 +70,13 @@ new AppSyncTransformer(scope: Construct, id: string, props: AppSyncTransformerPr
 Name | Type | Description 
 -----|------|-------------
 **appsyncAPI**🔹 | <code>[GraphqlApi](#aws-cdk-aws-appsync-graphqlapi)</code> | The cdk GraphqlApi construct.
-**functionResolvers**🔹 | <code>Map<string, Array<[CdkTransformerFunctionResolver](#cdk-appsync-transformer-cdktransformerfunctionresolver)>></code> | The Lambda Function resolvers designated by the function directive https://github.com/kcwinner/cdk-appsync-transformer#functions.
+**fieldResolvers**🔹 | <code>Map<string, Array<[Resolver](#aws-cdk-aws-appsync-resolver)>></code> | <span></span>
+**functionResolvers**🔹 | <code>Map<string, Array<[CdkTransformerFunctionResolver](#cdk-appsync-transformer-cdktransformerfunctionresolver)>></code> | The Lambda Function resolvers designated by the function directive https://github.com/kcwinner/cdk-appsync-transformer#functions.
 **httpResolvers**🔹 | <code>Map<string, Array<[CdkTransformerHttpResolver](#cdk-appsync-transformer-cdktransformerhttpresolver)>></code> | <span></span>
 **nestedAppsyncStack**🔹 | <code>[NestedStack](#aws-cdk-core-nestedstack)</code> | The NestedStack that contains the AppSync resources.
 **outputs**🔹 | <code>[SchemaTransformerOutputs](#cdk-appsync-transformer-schematransformeroutputs)</code> | The outputs from the SchemaTransformer.
 **resolvers**🔹 | <code>Map<string, [CdkTransformerResolver](#cdk-appsync-transformer-cdktransformerresolver)></code> | The AppSync resolvers from the transformer minus any function resolvers.
-**tableMap**🔹 | <code>Map<string, [Table](#aws-cdk-aws-dynamodb-table)></code> | Map of cdk table keys to L2 Table e.g. { 'TaskTable': Table }.
+**tableMap**🔹 | <code>Map<string, [Table](#aws-cdk-aws-dynamodb-table)></code> | Map of cdk table keys to L2 Table e.g. { 'TaskTable': Table }.
 **tableNameMap**🔹 | <code>Map<string, string></code> | Map of cdk table tokens to table names.
 
 ### Methods
@@ -87,7 +91,7 @@ addDynamoDBStream(props: DynamoDBStreamProps): string
 ```
 
 * **props** (<code>[DynamoDBStreamProps](#cdk-appsync-transformer-dynamodbstreamprops)</code>)  *No description*
-  * **modelTypeName** (<code>string</code>)  The @model type name from the graph schema e.g. Blog. 
+  * **modelTypeName** (<code>string</code>)  The @model type name from the graph schema e.g. Blog. 
   * **streamViewType** (<code>[StreamViewType](#aws-cdk-aws-dynamodb-streamviewtype)</code>)  *No description* 
 
 __Returns__:
@@ -95,7 +99,7 @@ __Returns__:
 
 #### addLambdaDataSourceAndResolvers(functionName, id, lambdaFunction, options?)🔹 <a id="cdk-appsync-transformer-appsynctransformer-addlambdadatasourceandresolvers"></a>
 
-Adds the function as a lambdaDataSource to the AppSync api Adds all of the functions resolvers to the AppSync api.
+Adds the function as a lambdaDataSource to the AppSync api Adds all of the functions resolvers to the AppSync api.
 
 ```ts
 addLambdaDataSourceAndResolvers(functionName: string, id: string, lambdaFunction: IFunction, options?: DataSourceOptions): LambdaDataSource
@@ -113,7 +117,7 @@ __Returns__:
 
 #### grantPrivate(grantee)🔹 <a id="cdk-appsync-transformer-appsynctransformer-grantprivate"></a>
 
-Adds an IAM policy statement granting access to the private fields of the AppSync API.
+Adds an IAM policy statement granting access to the private fields of the AppSync API.
 
 Policy is based off of the @auth transformer
 https://docs.amplify.aws/cli/graphql-transformer/auth
@@ -129,7 +133,7 @@ __Returns__:
 
 #### grantPublic(grantee)🔹 <a id="cdk-appsync-transformer-appsynctransformer-grantpublic"></a>
 
-Adds an IAM policy statement granting access to the public fields of the AppSync API.
+Adds an IAM policy statement granting access to the public fields of the AppSync API.
 
 Policy is based off of the @auth transformer
 https://docs.amplify.aws/cli/graphql-transformer/auth
@@ -153,7 +157,7 @@ overrideResolver(props: OverrideResolverProps): void
 
 * **props** (<code>[OverrideResolverProps](#cdk-appsync-transformer-overrideresolverprops)</code>)  *No description*
   * **fieldName** (<code>string</code>)  The fieldname to override e.g. listThings, createStuff. 
-  * **typeName** (<code>string</code>)  Example: Query, Mutation, Subscription For a GSI this might be Post, Comment, etc. 
+  * **typeName** (<code>string</code>)  Example: Query, Mutation, Subscription For a GSI this might be Post, Comment, etc. 
   * **requestMappingTemplateFile** (<code>string</code>)  The full path to the request mapping template file. __*Optional*__
   * **responseMappingTemplateFile** (<code>string</code>)  The full path to the resposne mapping template file. __*Optional*__
 
@@ -171,18 +175,21 @@ overrideResolver(props: OverrideResolverProps): void
 
 Name | Type | Description 
 -----|------|-------------
-**schemaPath**🔹 | <code>string</code> | Relative path where schema.graphql exists.
+**schemaPath**🔹 | <code>string</code> | Relative path to schema.graphql or a directory containing *.graphql schema files.
+**amplifyTransformers**?🔹 | <code>Array<any></code> | Optional.<br/>__*Default*__: undefined
 **apiName**?🔹 | <code>string</code> | String value representing the api name.<br/>__*Default*__: `${id}-api`
 **authorizationConfig**?🔹 | <code>[AuthorizationConfig](#aws-cdk-aws-appsync-authorizationconfig)</code> | Optional.<br/>__*Default*__: API_KEY authorization config
 **customVtlTransformerRootDirectory**?🔹 | <code>string</code> | The root directory to use for finding custom resolvers.<br/>__*Default*__: process.cwd()
-**dynamoDbStreamConfig**?🔹 | <code>Map<string, [StreamViewType](#aws-cdk-aws-dynamodb-streamviewtype)></code> | A map of @model type names to stream view type e.g { Blog: StreamViewType.NEW_IMAGE }.<br/>__*Optional*__
+**dynamoDbStreamConfig**?🔹 | <code>Map<string, [StreamViewType](#aws-cdk-aws-dynamodb-streamviewtype)></code> | A map of @model type names to stream view type e.g { Blog: StreamViewType.NEW_IMAGE }.<br/>__*Optional*__
 **enableDynamoPointInTimeRecovery**?🔹 | <code>boolean</code> | Whether to enable dynamo Point In Time Recovery.<br/>__*Default*__: false
+**featureFlags**?🔹 | <code>any</code> | Optional.<br/>__*Default*__: undefined
 **fieldLogLevel**?🔹 | <code>[FieldLogLevel](#aws-cdk-aws-appsync-fieldloglevel)</code> | Optional.<br/>__*Default*__: FieldLogLevel.NONE
 **nestedStackName**?🔹 | <code>string</code> | Specify a custom nested stack name.<br/>__*Default*__: "appsync-nested-stack"
 **postCdkTransformers**?🔹 | <code>Array<any></code> | Optional.<br/>__*Default*__: undefined
 **preCdkTransformers**?🔹 | <code>Array<any></code> | Optional.<br/>__*Default*__: undefined
 **syncEnabled**?🔹 | <code>boolean</code> | Whether to enable Amplify DataStore and Sync Tables.<br/>__*Default*__: false
 **tableNames**?🔹 | <code>Map<string, string></code> | A map of names to specify the generated dynamo table names instead of auto generated names.<br/>__*Default*__: undefined
+**transformConfig**?🔹 | <code>any</code> | Optional.<br/>__*Default*__: undefined
 **xrayEnabled**?🔹 | <code>boolean</code> | Determines whether xray should be enabled on the AppSync API.<br/>__*Default*__: false
 
 
@@ -322,7 +329,7 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|-------------
-**modelTypeName**🔹 | <code>string</code> | The @model type name from the graph schema e.g. Blog.
+**modelTypeName**🔹 | <code>string</code> | The @model type name from the graph schema e.g. Blog.
 **streamViewType**🔹 | <code>[StreamViewType](#aws-cdk-aws-dynamodb-streamviewtype)</code> | <span></span>
 
 
@@ -337,7 +344,7 @@ Name | Type | Description
 Name | Type | Description 
 -----|------|-------------
 **fieldName**🔹 | <code>string</code> | The fieldname to override e.g. listThings, createStuff.
-**typeName**🔹 | <code>string</code> | Example: Query, Mutation, Subscription For a GSI this might be Post, Comment, etc.
+**typeName**🔹 | <code>string</code> | Example: Query, Mutation, Subscription For a GSI this might be Post, Comment, etc.
 **requestMappingTemplateFile**?🔹 | <code>string</code> | The full path to the request mapping template file.<br/>__*Optional*__
 **responseMappingTemplateFile**?🔹 | <code>string</code> | The full path to the resposne mapping template file.<br/>__*Optional*__
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.78.0](https://github.com/kcwinner/cdk-appsync-transformer/compare/v1.77.5...v1.78.0) (2021-11-17)
+
+### Features
+
+* Capability to access resolvers to do deep configuration
+* Capability to reference a schema directory as an alternative to a pre-merged schema file.
+* Capability to modify transformConfig
+* Capability to modify amplifyTransformers
+* Capability to modify featureFlags
+
 ### [1.77.16](https://github.com/kcwinner/cdk-appsync-transformer/compare/v1.77.15...v1.77.16) (2021-06-15)
 
 

--- a/README.md
+++ b/README.md
@@ -391,7 +391,26 @@ const streamArn = appSyncTransformer.addDynamoDBStream({
 ### DataStore Support
 
 1. Pass `syncEnabled: true` to the `AppSyncTransformerProps`
-1. Generate necessary exports (see [Code Generation](#code-generation) below)
+2. Generate necessary exports (see [Code Generation](#code-generation) below)
+
+### Modifying resolver syncConfig
+
+1. Create `AppSyncTransformer`
+2. Access `Resolver` by your fieldName (e.g. Mutation `updateMyModel`)
+3. Access the CfnResolver via the Resolver's defaultChild;
+4. Modify CfnResolver.syncConfig
+
+```ts
+const transformer = new AppSyncTransformer(myConfig)
+const cfnResolver = transformer.fieldResolvers['updateMyModel']?.[0]!
+        .node.defaultChild as CfnResolver | undefined;
+if (cfnResolver) {
+  cfnResolver.syncConfig = {
+    conflictDetection: 'VERSION',
+    conflictHandler: 'OPTIMISTIC_CONCURRENCY',
+  };
+}
+```
 
 ### Cfn Outputs
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export {
   CdkTransformerResolver,
   CdkTransformerFunctionResolver,
+  CdkTransformerFieldFunctionResolver,
   CdkTransformerHttpResolver,
   CdkTransformerLocalSecondaryIndex,
   CdkTransformerGlobalSecondaryIndex,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,5 @@ export {
 } from './transformer';
 
 export * from './appsync-transformer';
+
+

--- a/src/transformer/cdk-transformer.ts
+++ b/src/transformer/cdk-transformer.ts
@@ -53,6 +53,11 @@ export interface CdkTransformerFunctionResolver extends CdkTransformerResolver {
   readonly defaultResponseMappingTemplate: string;
 }
 
+export interface CdkTransformerFieldFunctionResolver extends CdkTransformerResolver {
+  readonly requestMappingTemplate: string;
+  readonly responseMappingTemplate: string;
+}
+
 export class CdkTransformer extends Transformer {
   tables: { [name: string]: CdkTransformerTable };
   noneDataSources: { [name: string]: CdkTransformerResolver };

--- a/src/transformer/schema-transformer.ts
+++ b/src/transformer/schema-transformer.ts
@@ -260,6 +260,21 @@ export class SchemaTransformer {
           } else if (templateType === 'res') {
             this.resolvers[compositeKey].responseMappingTemplate = filepath;
           }
+        } else if (this.isFunctionResolver(typeName, fieldName)) {
+          if (!this.resolvers.lambdaFieldResolvers) {
+            this.resolvers.lambdaFieldResolvers = {};
+          }
+          if (!this.resolvers.lambdaFieldResolvers[compositeKey]) {
+            this.resolvers.lambdaFieldResolvers[compositeKey] = {
+              typeName: typeName,
+              fieldName: fieldName,
+            };
+          }
+          if (templateType === 'req') {
+            this.resolvers.lambdaFieldResolvers[compositeKey].requestMappingTemplate = filepath;
+          } else if (templateType === 'res') {
+            this.resolvers.lambdaFieldResolvers[compositeKey].responseMappingTemplate = filepath;
+          }
         } else { // This is a GSI
           if (!this.resolvers.gsi) {
             this.resolvers.gsi = {};
@@ -371,6 +386,20 @@ export class SchemaTransformer {
     } catch (err) {
       return config;
     }
+  }
+
+  private isFunctionResolver(typeName: string, fieldName: string) {
+    if (!this.outputs.functionResolvers) {
+      return false;
+    }
+    for (const endpoint in this.outputs.functionResolvers) {
+      for (const resolver of this.outputs.functionResolvers[endpoint]) {
+        if (resolver.typeName === typeName && resolver.fieldName === fieldName) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -14,6 +14,7 @@ import { KeyTransformer } from 'graphql-key-transformer';
 import { AppSyncTransformer } from '../src/index';
 import MappedTransformer from './mappedTransformer';
 import SingleFieldMapTransformer from './singleFieldMapTransformer';
+import {HttpTransformer} from "graphql-http-transformer";
 // eslint-disable-next-line
 const { FunctionTransformer } = require('graphql-function-transformer') as any;
 
@@ -1278,7 +1279,7 @@ test('Can override amplifyTransformers', () => {
   })).toThrow();
   expect(() => new AppSyncTransformer(stack, 'amplifyTransformers-noThrow', {
     schemaPath: path.resolve(__dirname, 'schema-directory'),
-    amplifyTransformers: [new DynamoDBModelTransformer(), new KeyTransformer(), new FunctionTransformer()],
+    amplifyTransformers: [new DynamoDBModelTransformer(), new KeyTransformer(), new HttpTransformer(), new FunctionTransformer()],
   })).not.toThrow();
 });
 
@@ -1288,7 +1289,7 @@ test('Lambda resources use provided schema', () => {
 
   const transformer = new AppSyncTransformer(stack, 'amplifyTransformers-noThrow', {
     schemaPath: path.resolve(__dirname, 'schema-directory'),
-    amplifyTransformers: [new DynamoDBModelTransformer(), new KeyTransformer(), new FunctionTransformer()],
+    amplifyTransformers: [new DynamoDBModelTransformer(), new KeyTransformer(), new HttpTransformer(), new FunctionTransformer()],
   });
   expect(transformer);
 });

--- a/test/schema-directory/run.graphql
+++ b/test/schema-directory/run.graphql
@@ -1,0 +1,7 @@
+type Run
+@model
+@key(fields: ["id"])
+{
+    id:             ID!
+    input: [VariableDeclaration!]!
+}

--- a/test/schema-directory/run.graphql
+++ b/test/schema-directory/run.graphql
@@ -2,6 +2,6 @@ type Run
 @model
 @key(fields: ["id"])
 {
-    id:             ID!
+    id:             ID! @http(url: "https://www.example.com/runById")
     input: [VariableDeclaration!]!
 }

--- a/test/schema-directory/test.graphql
+++ b/test/schema-directory/test.graphql
@@ -5,6 +5,7 @@ type Test
     id:             ID!
     name:           String!
     input: [VariableDeclaration!]!
+    delegate: String @function(name: "testFn")
 }
 
 type VariableDeclaration {

--- a/test/schema-directory/test.graphql
+++ b/test/schema-directory/test.graphql
@@ -1,0 +1,13 @@
+type Test
+@model
+@key(fields: ["id"])
+{
+    id:             ID!
+    name:           String!
+    input: [VariableDeclaration!]!
+}
+
+type VariableDeclaration {
+    variable: String!
+    value: String!
+}


### PR DESCRIPTION
  * Capability to access resolvers to do deep configuration
  * Capability to modify transformConfig
  * Capability to modify amplifyTransformers
  * Capability to modify featureFlags
  * Capability to pass a directory schema path which will merge all schema files in that directory before applying the transformers.
  * Use the appsync-generated lambda resolvers for functions applied to schema fields 

Fixes #326
Fixes #325
Fixes #324
Fixes #323
Fixes #321
Fixes #320